### PR TITLE
Add support for enabling high-precision timestamps

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ rsyslog_config: false
 # defines primary domain name
 rsyslog_pri_domain_name: example.org
 
+# defines if high precision timestamps should be used instead of the traditional log format
+rsyslog_highprecision: false
+
 # defines if rsyslog should be configured to listen on tcp/514
 rsyslog_allow_tcp: false
 

--- a/templates/etc/rsyslog.conf.j2
+++ b/templates/etc/rsyslog.conf.j2
@@ -33,11 +33,19 @@ $KLogPermitNonKernelFacility on
 #### GLOBAL DIRECTIVES ####
 ###########################
 
+{% if (rsyslog_highprecision is defined and not rsyslog_highprecision) %}
 #
 # Use traditional timestamp format.
 # To enable high precision timestamps, comment out the following line.
 #
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+{% elif rsyslog_highprecision is defined and rsyslog_highprecision %}
+#
+# Use high precision timestamp format.
+# To enable traditional low-precision timestamps, uncomment the following line.
+#
+#$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+{% endif %}
 
 # Filter duplicated messages
 $RepeatedMsgReduction on


### PR DESCRIPTION
This pull requests adds support for enabling the newer rsyslog format that includes high precision timestamps. The default configuration remains unchanged.