### PR TITLE
Add support for specifying the TCP/UDP port rsyslog listens on

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,8 +10,14 @@ rsyslog_pri_domain_name: example.org
 # defines if rsyslog should be configured to listen on tcp/514
 rsyslog_allow_tcp: false
 
+# sets the TCP port rsyslog should listen on if TCP is enabled. 514 is the IANA assigned port
+rsyslog_tcp_port: 514
+
 # defines if rsyslog should be configured to listen on udp/514
 rsyslog_allow_udp: false
+
+# sets the UDP port rsyslog should listen on if UDP is enabled. 514 is the IANA assigned port
+rsyslog_udp_port: 514
 
 # defines remote syslog servers
 rsyslog_servers: []

--- a/templates/etc/rsyslog.conf.j2
+++ b/templates/etc/rsyslog.conf.j2
@@ -14,7 +14,11 @@ $ModLoad imklog   # provides kernel logging support
 #$UDPServerRun 514
 {% elif rsyslog_allow_udp is defined and rsyslog_allow_udp %}
 $ModLoad imudp
+{% if rsyslog_udp_port is defined %}
+$UDPServerRun {{ rsyslog_udp_port }}
+{% else %}
 $UDPServerRun 514
+{% endif %}
 {% endif %}
 
 # provides TCP syslog reception
@@ -23,7 +27,11 @@ $UDPServerRun 514
 #$InputTCPServerRun 514
 {% elif rsyslog_allow_tcp is defined and rsyslog_allow_tcp %}
 $ModLoad imtcp
+{% if rsyslog_tcp_port is defined %}
+$InputTCPServerRun {{ rsyslog_tcp_port }}
+{% else %}
 $InputTCPServerRun 514
+{% endif %}
 {% endif %}
 
 # Enable non-kernel facility klog messages


### PR DESCRIPTION
This pull request adds support for setting the TCP and UDP port numbers when enabling TCP and UDP listening. The default port remains 514.

This is particularly useful for receiving log messages when running the rsyslog daemon in unprivileged mode.