### PR TITLE
Support templates for each destination server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,11 +22,21 @@ rsyslog_allow_udp: false
 # sets the UDP port rsyslog should listen on if UDP is enabled. 514 is the IANA assigned port
 rsyslog_udp_port: 514
 
+# defines specialized templates for remote syslog servers
+rsyslog_templates: []
+#  - name: 'GRAYLOGRFC5424'
+#    template: '<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msg%\n'
+#  - name: 'logstash'
+#    template: '<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %msg%\n'
+
+GRAYLOGRFC5424,"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msg%\n"
+
 # defines remote syslog servers
 rsyslog_servers: []
 #  - name: 'graylog.{{ rsyslog_pri_domain_name }}'
 #    proto: udp
 #    port: 514
+#    template: 'GRAYLOGRFC5424' #optional
 #  - name: 'logstash.{{ rsyslog_pri_domain_name }}'
 #    proto: tcp
 #    port: 514

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,8 +29,6 @@ rsyslog_templates: []
 #  - name: 'logstash'
 #    template: '<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %msg%\n'
 
-GRAYLOGRFC5424,"<%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% %procid% %msg%\n"
-
 # defines remote syslog servers
 rsyslog_servers: []
 #  - name: 'graylog.{{ rsyslog_pri_domain_name }}'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ rsyslog_config: false
 # defines primary domain name
 rsyslog_pri_domain_name: example.org
 
+# defines if high precision timestamps should be used instead of the traditional log format
+rsyslog_highprecision: false
+
 # defines if rsyslog should be configured to listen on tcp/514
 rsyslog_allow_tcp: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,8 +10,14 @@ rsyslog_pri_domain_name: example.org
 # defines if rsyslog should be configured to listen on tcp/514
 rsyslog_allow_tcp: false
 
+# sets the TCP port rsyslog should listen on if TCP is enabled. 514 is the IANA assigned port
+rsyslog_tcp_port: 514
+
 # defines if rsyslog should be configured to listen on udp/514
 rsyslog_allow_udp: false
+
+# sets the UDP port rsyslog should listen on if UDP is enabled. 514 is the IANA assigned port
+rsyslog_udp_port: 514
 
 # defines remote syslog servers
 rsyslog_servers: []

--- a/templates/etc/rsyslog.conf.j2
+++ b/templates/etc/rsyslog.conf.j2
@@ -33,11 +33,19 @@ $KLogPermitNonKernelFacility on
 #### GLOBAL DIRECTIVES ####
 ###########################
 
+{% if (rsyslog_highprecision is defined and not rsyslog_highprecision) %}
 #
 # Use traditional timestamp format.
 # To enable high precision timestamps, comment out the following line.
 #
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+{% elif rsyslog_highprecision is defined and rsyslog_highprecision %}
+#
+# Use high precision timestamp format.
+# To enable traditional low-precision timestamps, uncomment the following line.
+#
+#$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+{% endif %}
 
 # Filter duplicated messages
 $RepeatedMsgReduction on

--- a/templates/etc/rsyslog.conf.j2
+++ b/templates/etc/rsyslog.conf.j2
@@ -14,7 +14,11 @@ $ModLoad imklog   # provides kernel logging support
 #$UDPServerRun 514
 {% elif rsyslog_allow_udp is defined and rsyslog_allow_udp %}
 $ModLoad imudp
+{% if rsyslog_udp_port is defined %}
+$UDPServerRun {{ rsyslog_udp_port }}
+{% else %}
 $UDPServerRun 514
+{% endif %}
 {% endif %}
 
 # provides TCP syslog reception
@@ -23,7 +27,11 @@ $UDPServerRun 514
 #$InputTCPServerRun 514
 {% elif rsyslog_allow_tcp is defined and rsyslog_allow_tcp %}
 $ModLoad imtcp
+{% if rsyslog_tcp_port is defined %}
+$InputTCPServerRun {{ rsyslog_tcp_port }}
+{% else %}
 $InputTCPServerRun 514
+{% endif %}
 {% endif %}
 
 # Enable non-kernel facility klog messages

--- a/templates/etc/rsyslog.d/50-default.conf.j2
+++ b/templates/etc/rsyslog.d/50-default.conf.j2
@@ -1,13 +1,20 @@
 {{ ansible_managed|comment }}
 
+{% if rsyslog_templates is defined %}
+#server-specific templates
+{%   for item in rsyslog_templates %}
+$template {{ item.name }} "{{ item.tamplate }}"
+{%   endfor %}
+{% endif %}
+
 # Set our initial redirects here to ensure we catch everything
 {% if rsyslog_servers is defined %}
 {%   for item in rsyslog_servers %}
 {%     if item.proto == "tcp" %}
-*.* @@{{ item.name }}:{{ item.port }}
+*.* @@{{ item.name }}:{{ item.port }}{% if item.template is defined %};{{item.template}}{% endif %}
 {%     endif %}
 {%     if item.proto == "udp" %}
-*.* @{{ item.name }}:{{ item.port }}
+*.* @{{ item.name }}:{{ item.port }}{% if item.template is defined %};{{item.template}}{% endif %}
 {%     endif %}
 {%   endfor %}
 {% endif %}

--- a/templates/etc/rsyslog.d/50-default.conf.j2
+++ b/templates/etc/rsyslog.d/50-default.conf.j2
@@ -3,7 +3,7 @@
 {% if rsyslog_templates is defined %}
 #server-specific templates
 {%   for item in rsyslog_templates %}
-$template {{ item.name }} "{{ item.template }}"
+$template {{ item.name }},"{{ item.template }}"
 {%   endfor %}
 {% endif %}
 
@@ -18,6 +18,7 @@ $template {{ item.name }} "{{ item.template }}"
 {%     endif %}
 {%   endfor %}
 {% endif %}
+
 
 #
 # First some standard log files.  Log by facility.

--- a/templates/etc/rsyslog.d/50-default.conf.j2
+++ b/templates/etc/rsyslog.d/50-default.conf.j2
@@ -3,7 +3,7 @@
 {% if rsyslog_templates is defined %}
 #server-specific templates
 {%   for item in rsyslog_templates %}
-$template {{ item.name }} "{{ item.tamplate }}"
+$template {{ item.name }} "{{ item.template }}"
 {%   endfor %}
 {% endif %}
 


### PR DESCRIPTION
This pull request adds support for specifying a template string that can then be applied to a specific remote server configuration. This change is backwards-compatible, but this particular pull request was only tested with PR #3 and PR #4  already applied.