### PR TITLE
Make defaults section customizable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,7 +84,7 @@ rsyslog_localfiles:
     selectors: 'news.crit'
   - name: '/var/log/news/news.err'
     selectors: 'news.err'
-  - name: '/var/log/news/news.notice
+  - name: '/var/log/news/news.notice'
     proto: 'nosync'
     selectors: 'news.notice'
 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,9 +27,15 @@ rsyslog_servers: []
 #  - name: 'graylog.{{ rsyslog_pri_domain_name }}'
 #    proto: udp
 #    port: 514
+#    selectors:
+#      - 'authpriv.*'
 #  - name: 'logstash.{{ rsyslog_pri_domain_name }}'
 #    proto: tcp
 #    port: 514
+#    selectors:
+#      - '*.warn'
 #  - name: localhost  #good for redirecting back itself..ex. logstash running on tcp/udp 10514...to get around logstash running on ports < 1024
 #    proto: tcp
 #    port: 10514
+#    selectors:
+#      - '*.*'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,3 +39,114 @@ rsyslog_servers: []
 #    port: 10514
 #    selectors:
 #      - '*.*'
+
+# defines rsyslog outputs to local log files:
+rsyslog_localfiles:
+  - name: '/var/log/auth.log'
+    proto: 'file'
+    selectors: 'auth,authpriv.*'
+  - name: '/var/log/syslog'
+    proto: 'nosync'
+    selectors:
+      - '*.*'
+      - 'auth,authpriv.none'
+# - name: '/var/log/cron.log
+#   selectors: ['cron.*']
+# - name: '/var/log/daemon.log'
+#   selectors: 'daemon.*'
+  - name: '/var/log/kern.log'
+    proto: 'nosync'
+    selectors: 'kern.*'
+# - name: '/var/log/lpr.log'
+#   proto: 'nosync'
+#   selectors: 'lpr.*'
+  - name: '/var/log/mail.log'
+    selectors: 'mail.*'
+# - name: '/var/log/user.log'
+#   selectors: 'user.*'
+#
+# Logging for the mail system.  Split it up so that
+# it is easy to write scripts to parse these files.
+#
+# - name: '/var/log/mail.info'
+#   proto: 'nosync'
+#   selectors: 'mail.info'
+# - name: '/var/log/mail.warn'
+#   proto: 'nosync'
+#   selectors: 'mail.warn'
+  - name: '/var/log/mail.err'
+    selectors: 'mail.err'
+#
+#
+# Logging for INN news system.
+#
+  - name: '/var/log/news/news.crit'
+    selectors: 'news.crit'
+  - name: '/var/log/news/news.err'
+    selectors: 'news.err'
+  - name: '/var/log/news/news.notice
+    proto: 'nosync'
+    selectors: 'news.notice'
+#
+# Some "catch-all" log files.
+#
+# - name: '/var/log/debug'
+#   proto: 'nosync'
+#   selectors:
+#     - '*.=debug'
+#     - 'auth,authpriv.none'
+#     -	'news.none'
+#     - 'mail.none'
+# - name: '/var/log/messages'
+#   proto: 'nosync'
+#   selectors:
+#     - '*.=info'
+#     - '*.=notice'
+#     - '*.=warn'
+#     - 'auth,authpriv.none'
+#     - 'cron,daemon.none'
+#     - 'mail,news.none'
+#
+
+rsyslog_devices:
+# Emergencies are sent to everybody logged in.
+#
+  - name: ':omusrmsg:*'
+    selectors: '*.emerg'
+#
+# I like to have messages displayed on the console, but only on a virtual
+# console I usually leave idle.
+#
+# - name: '/dev/tty8'
+#   selectors:
+#     - 'daemon,mail.*'
+#     - 'news.=crit'
+#     - 'news.=err'
+#     - 'news.=notice'
+#     - '*.=debug'
+#     - '*.=info'
+#     - '*.=notice'
+#     - '*.=warn'
+#
+# The named pipe /dev/xconsole is for the `xconsole' utility.  To use it,
+# you must invoke `xconsole' with the `-file' option:
+#
+#    $ xconsole -file /dev/xconsole [...]
+#
+# NOTE: adjust the list below, or you'll go crazy if you have a reasonably
+#      busy site..
+#
+  - name: '/dev/xconsole'
+    proto: 'pipe'
+    selectors:
+      - 'daemon.*'
+      - 'mail.*'
+      - 'news.err'
+      - '*.=debug'
+      - '*.=info'
+      - '*.=notice'
+      - '*.=warn'
+
+rsyslog_defaults: '{{ rsyslog_servers
+               |union(rsyslog_localfiles)
+	       |union(rsyslog_devices) }}'

--- a/templates/etc/rsyslog.d/50-default.conf.j2
+++ b/templates/etc/rsyslog.d/50-default.conf.j2
@@ -3,11 +3,16 @@
 # Set our initial redirects here to ensure we catch everything
 {% if rsyslog_servers is defined %}
 {%   for item in rsyslog_servers %}
+{%     selector = item.selectors|default(['*.*'])|join(';') %}
 {%     if item.proto == "tcp" %}
-*.* @@{{ item.name }}:{{ item.port }}
+{%       prefix = '@@' %}
+{%     elif item.proto == "udp" %}
+{%       prefix = '@' %}
+{%     else %}
+{%       continue %}
 {%     endif %}
-{%     if item.proto == "udp" %}
-*.* @{{ item.name }}:{{ item.port }}
+{%     if item.name|length>0 and item.port|int>0 %}
+{{ selector }} {{ prefix }}{{ item.name }}:{{ item.port }}
 {%     endif %}
 {%   endfor %}
 {% endif %}

--- a/templates/etc/rsyslog.d/50-default.conf.j2
+++ b/templates/etc/rsyslog.d/50-default.conf.j2
@@ -1,83 +1,25 @@
 {{ ansible_managed|comment }}
 
 # Set our initial redirects here to ensure we catch everything
-{% if rsyslog_servers is defined %}
-{%   for item in rsyslog_servers %}
-{%     selector = item.selectors|default(['*.*'])|join(';') %}
-{%     if item.proto == "tcp" %}
+{% for item in rsyslog_defaults %}
+{%   if item.name|length>0 %}
+{%     selector = [item.selectors|default('*.*')]|flatten|join(';') %}
+{%     if item.proto == "nosync" %}
+{%       prefix = '-' %}
+{%     elif item.proto == 'pipe' %}
+{%       prefix = '|' %}
+{%     elif item.proto == 'tcp' %}
 {%       prefix = '@@' %}
-{%     elif item.proto == "udp" %}
+{%     elif item.proto == 'udp' %}
 {%       prefix = '@' %}
 {%     else %}
-{%       continue %}
+{%       prefix = '' %}
 {%     endif %}
-{%     if item.name|length>0 and item.port|int>0 %}
-{{ selector }} {{ prefix }}{{ item.name }}:{{ item.port }}
+{%     if item.port|int>0 %}
+{%       suffix = ':' & item.port %}
+{%     else %}
+{%       suffix = '' %}
 {%     endif %}
+{{ selector }} {{ prefix }}{{ item.name }}{{ suffix }}
 {%   endfor %}
 {% endif %}
-
-#
-# First some standard log files.  Log by facility.
-#
-auth,authpriv.*			/var/log/auth.log
-*.*;auth,authpriv.none 		-/var/log/syslog
-#cron.*				/var/log/cron.log
-#daemon.*      			-/var/log/daemon.log
-kern.* 				-/var/log/kern.log
-#lpr.* 				-/var/log/lpr.log
-mail.* 				-/var/log/mail.log
-#user.*				-/var/log/user.log
-
-#
-# Logging for the mail system.  Split it up so that
-# it is easy to write scripts to parse these files.
-#
-#mail.info     			-/var/log/mail.info
-#mail.warn     			-/var/log/mail.warn
-mail.err       			/var/log/mail.err
-
-#
-# Logging for INN news system.
-#
-news.crit      			/var/log/news/news.crit
-news.err       			/var/log/news/news.err
-news.notice    			-/var/log/news/news.notice
-
-#
-# Some "catch-all" log files.
-#
-#*.=debug;\
-#      	auth,authpriv.none;\
-#      	news.none;mail.none    	-/var/log/debug
-#*.=info;*.=notice;*.=warn;\
-#      	auth,authpriv.none;\
-#      	cron,daemon.none;\
-#      	mail,news.none 		-/var/log/messages
-
-#
-# Emergencies are sent to everybody logged in.
-#
-*.emerg                                :omusrmsg:*
-
-#
-# I like to have messages displayed on the console, but only on a virtual
-# console I usually leave idle.
-#
-#daemon,mail.*;\
-#      	news.=crit;news.=err;news.=notice;\
-#      	*.=debug;*.=info;\
-#      	*.=notice;*.=warn      	/dev/tty8
-
-# The named pipe /dev/xconsole is for the `xconsole' utility.  To use it,
-# you must invoke `xconsole' with the `-file' option:
-#
-#    $ xconsole -file /dev/xconsole [...]
-#
-# NOTE: adjust the list below, or you'll go crazy if you have a reasonably
-#      busy site..
-#
-daemon.*;mail.*;\
-       	news.err;\
-       	*.=debug;*.=info;\
-       	*.=notice;*.=warn      	|/dev/xconsole


### PR DESCRIPTION
This allows customizing the `/etc/rsyslog.d/50-defaults.conf` file through variables rather than by hand-editing the template or the target file itself.
